### PR TITLE
Cambio en medida relativa para las fuentes

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,5 +1,7 @@
 html {
   box-sizing: border-box;
+  font-size: 62.5%;
+  
 }
 *, *:before, *:after {
   box-sizing: inherit;
@@ -7,19 +9,20 @@ html {
 
 body {
   color: #4b8e8e;
+  font-size: 1.6rem;
   font-family: Mulish, sans-serif;
 }
 
 header {
   display: flex;
-  font-size: 1.5rem;
-  height: 3.75rem;
+  font-size: 2.4rem; /*1.5rem;*/
+  height: 6rem; /*3.75rem*/
   align-items: center;
 }
 
 header .logo {
-  height: 1.5rem;
-  margin-left: 1.5rem;
+  height: 2.4rem; /* 1.5rem;*/
+  margin-left: 2.4rem; /*1.5rem*/
 }
 
 @media (max-width: 425px) {
@@ -36,9 +39,9 @@ header .logo {
   color: white;
   display: flex;
   flex-wrap: wrap;
-  height: 32.8125rem;
+  height: 52.5rem; /*32.8125rem;*/
   justify-content: center;
-  padding: 0 20rem;
+  padding: 0 32rem;/* 20rem;*/
 }
 
 @media (max-width: 425px) {
@@ -49,21 +52,21 @@ header .logo {
 }
 
 .welcome h2 {
-  font-size: 2.625rem;
+  font-size: 4.2rem; /*2.625rem;*/
   text-align: center;
 }
 
 @media (max-width: 425px) {
   .welcome h2 {
-    font-size: 2rem;
-    line-height: 2.25rem;
-    padding: 1rem;
+    font-size: 3.2rem; /*2rem;*/
+    line-height: 3.6rem; /*2.25rem;*/
+    padding: 1.6rem; /* 1rem;*/
   }
 }
 
 .introduction {
   background: #4b8e8e;
-  height: 21.40625rem;
+  height: 34.25rem; /*21.40625rem;*/
   text-align: center;
 }
 
@@ -74,32 +77,32 @@ header .logo {
 }
 
 .introduction h4 {
-  font-size: 1.875rem;
+  font-size: 3rem; /*1.875rem;*/
   font-weight: bolder;
   margin: 0;
 }
 
 .introduction p {
-  font-size: 1.09375rem;
+  font-size: 1.75rem; /*1.09375rem;*/
 }
 
 .bubble {
   background: #4b8e8e;
   color: white;
   display: inline-block;
-  height: 21.40625rem;
-  margin: 0 6rem;
-  padding: 3.75rem 1.40625rem;
+  height: 34.25rem; /*21.40625rem;*/
+  margin: 0 9.6rem; /*6rem;*/
+  padding: 6rem 2.25rem; /*3.75rem 1.40625rem;*/
   vertical-align: top;
   text-align: left;
-  width: 21.25rem;
+  width: 34rem; /*21.25rem;*/
 }
 
 @media (max-width: 425px) {
   .bubble {
     height: auto;
     margin: 0;
-    padding: 4rem 2.5rem;
+    padding: 6.4rem 4rem ;/*4rem 2.5rem;*/
     text-align: center;
   }
 }
@@ -107,24 +110,24 @@ header .logo {
 .call-to-action {
   background: #04102F;
   color: white;
-  height: 21.40625rem;
-  padding: 3.75rem;
+  height: 34.25rem; /*21.40625rem;*/
+  padding: 6rem; /*3.75rem;*/
   position: relative;
 }
 
 @media (max-width: 425px) {
   .call-to-action {
     height: auto;
-    padding: 2rem;
+    padding: 3.2rem; /*2rem;*/
     text-align: center;
   }
 }
 
 .call-to-action .description {
-  font-size: 1.40rem;
-  line-height: 1.80rem;
-  margin-bottom: 1.125rem;
-  width: 31.25rem;
+  font-size: 2.24rem; /*1.40rem;*/
+  line-height: 2.88rem; /*1.80rem;*/
+  margin-bottom: 1.8rem; /*1.125rem;*/
+  width: 50rem; /*31.25rem;*/
 }
 
 @media (max-width: 425px) {
@@ -150,7 +153,7 @@ header .logo {
   box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
   color: white;
   cursor: pointer;
-  padding: 0.78125rem 2.96875rem;
+  padding: 1.25rem 4.75rem; /*0.78125rem 2.96875rem;*/
   text-align: center;
   text-decoration: none;
 }
@@ -161,18 +164,18 @@ header .logo {
 
 .call-to-action .want-to-help {
   position: absolute;
-  right: 12.5rem;
-  top: 9.2rem;
+  right: 20rem; /*12.5rem;*/
+  top: 14.72rem; /*9.2rem;*/
 }
 
 @media (max-width: 425px) {
   .call-to-action .want-to-help {
     display: block;
-    margin: 3rem auto 0;
+    margin: 4.8rem auto 0; /*3rem auto 0;*/
     position: relative;
     right: auto;
     top: auto;
-    width: 17rem;
+    width: 27.2rem; /*17rem;*/
   }
 }
 
@@ -180,16 +183,16 @@ footer {
   background: #272828;
   color: white;
   display: flex;
-  height: 16.5rem;
+  height: 26.4rem; /*16.5rem;*/
   justify-content: space-between;
-  padding: 5rem 13rem 0 3.8rem;
+  padding: 8rem 20.8rem 0 6.08rem; /*5rem 13rem 0 3.8rem;*/
 }
 
 @media (max-width: 425px) {
   footer {
     display: block;
     height: auto;
-    padding: 2.5rem 0 2.5rem 1.5rem;
+    padding: 4rem 0 4rem 2.4rem; /*2.5rem 0 2.5rem 1.5rem;*/
   }
 }
 
@@ -198,28 +201,28 @@ footer p {
 }
 
 footer .signature {
-  margin-top: .5rem;
+  margin-top: 0.8rem; /* .5rem;*/
   opacity: .6;
 }
 
 @media (max-width: 425px) {
   footer .social {
-    margin-top: 2rem;
+    margin-top: 3.2rem; /*2rem;*/
   }
 }
 
 footer .email {
-  margin-top: .5rem;
+  margin-top: 0.8rem; /*.5rem;*/
   opacity: .6;
   text-decoration: underline;
 }
 
 footer .networks {
-  margin-top: 2rem;
+  margin-top: 3.2rem; /*2rem;*/
 }
 
 footer .networks a {
   color: white;
-  margin-right: 1rem;
+  margin-right: 1.6rem; /*1rem;*/
   text-decoration: none;
 }


### PR DESCRIPTION
Deseo contribuir al proyecto, encontré un punto en el cuál usan las medidas relativas rem y creé la siguiente propuesta: 

Agregue un valor de font-size de 62.5% a la etiqueta HTML, esto permite que los desarrolladores al querer ingresar una medida de tipo rem se le haga más fácil, por ejemplo ahora que el font-size es 62.5% si quiero asignar 42px a un texto solo tendría que dividirlo entre 10 y así tendría el valor que sería 4.2rem, por como iban las medidas antes de esta sugerencia, esta medida tendría que ser 2.625rem que se hace un poco complicado de leer; de igual forma agregue una medida a la etiqueta body de 16px.
Los cambios realizados no afectan en nada a la página actual, ya comprobé que sea así.  